### PR TITLE
Add the URL to the spool to the NFC tag information.

### DIFF
--- a/app/src/main/java/com/hexxotest/spoolcompanion/MainActivity.kt
+++ b/app/src/main/java/com/hexxotest/spoolcompanion/MainActivity.kt
@@ -97,21 +97,20 @@ class MainActivity : ComponentActivity() {
             val tag: Tag = IntentCompat.getParcelableExtra(
                 intent,
                 NfcAdapter.EXTRA_TAG,
-                Parcelable::class.java
-            ) as Tag
+                Tag::class.java
+            ) ?: return
+
             if (nfcTagViewModel.isDialogShown) {
                 val url = nfcTagViewModel.spoolmanUrl
-                if (!url.isNullOrBlank()) {
-                    Log.w(
-                        "NFC",
-                        "SPOOL:${nfcTagViewModel.spoolId} | FILAMENT:${nfcTagViewModel.filamentId} | SPOOLMANURL:${url}"
-                    )
-                } else {
-                    Log.w(
-                        "NFC",
-                        "SPOOL:${nfcTagViewModel.spoolId} | FILAMENT:${nfcTagViewModel.filamentId}"
-                    )
-                }
+                val writeUrlToNfc = nfcTagViewModel.addUrlToNfc && !url.isNullOrBlank()
+                Log.w("NFC", buildString {
+                    append("SPOOL:${nfcTagViewModel.spoolId} | FILAMENT:${nfcTagViewModel.filamentId}")
+                    if (url.isNullOrBlank()) {
+                        append(" | no URL available")
+                    } else {
+                        append(" | SPOOLMANURL:$url | ADDNFC:$writeUrlToNfc")
+                    }
+                })
                 
                 // Payload format is a two-line text record consumed by the companion tool.
                 val records = mutableListOf<NdefRecord>()
@@ -119,12 +118,12 @@ class MainActivity : ComponentActivity() {
                     null,
                     "SPOOL:${nfcTagViewModel.spoolId}\nFILAMENT:${nfcTagViewModel.filamentId}"
                 ))
-                if (!url.isNullOrBlank() && nfcTagViewModel.spoolId != -1) {
+                if (writeUrlToNfc && nfcTagViewModel.spoolId != -1) {
                     try {
                         val spoolmanDeepLink = "$url/spool/show/${nfcTagViewModel.spoolId}"
                         records.add(NdefRecord.createUri(spoolmanDeepLink))
                     } catch (e: IllegalArgumentException) {
-                        Log.e("NFC", "Failed to create URI record for: $url/spool/view/${nfcTagViewModel.spoolId}", e)
+                        Log.e("NFC", "Failed to create URI record for: $url/spool/show/${nfcTagViewModel.spoolId}", e)
                     }
                 }
                 val msg = NdefMessage(records.toTypedArray())

--- a/app/src/main/java/com/hexxotest/spoolcompanion/MainActivity.kt
+++ b/app/src/main/java/com/hexxotest/spoolcompanion/MainActivity.kt
@@ -100,17 +100,35 @@ class MainActivity : ComponentActivity() {
                 Parcelable::class.java
             ) as Tag
             if (nfcTagViewModel.isDialogShown) {
-                Log.w(
-                    "NFC",
-                    "SPOOL:${nfcTagViewModel.spoolId} | FILAMENT:${nfcTagViewModel.filamentId}"
-                )
-                // Payload format is a two-line text record consumed by the companion tool.
-                val msg = NdefMessage(
-                    NdefRecord.createTextRecord(
-                        null,
-                        "SPOOL:${nfcTagViewModel.spoolId}\nFILAMENT:${nfcTagViewModel.filamentId}"
+                val url = nfcTagViewModel.spoolmanUrl
+                if (!url.isNullOrBlank()) {
+                    Log.w(
+                        "NFC",
+                        "SPOOL:${nfcTagViewModel.spoolId} | FILAMENT:${nfcTagViewModel.filamentId} | SPOOLMANURL:${url}"
                     )
-                )
+                } else {
+                    Log.w(
+                        "NFC",
+                        "SPOOL:${nfcTagViewModel.spoolId} | FILAMENT:${nfcTagViewModel.filamentId}"
+                    )
+                }
+                
+                // Payload format is a two-line text record consumed by the companion tool.
+                val records = mutableListOf<NdefRecord>()
+                records.add(NdefRecord.createTextRecord(
+                    null,
+                    "SPOOL:${nfcTagViewModel.spoolId}\nFILAMENT:${nfcTagViewModel.filamentId}"
+                ))
+                if (!url.isNullOrBlank() && nfcTagViewModel.spoolId != -1) {
+                    try {
+                        val spoolmanDeepLink = "$url/spool/show/${nfcTagViewModel.spoolId}"
+                        records.add(NdefRecord.createUri(spoolmanDeepLink))
+                    } catch (e: IllegalArgumentException) {
+                        Log.e("NFC", "Failed to create URI record for: $url/spool/view/${nfcTagViewModel.spoolId}", e)
+                    }
+                }
+                val msg = NdefMessage(records.toTypedArray())
+
                 // Some tags are not NDEF-formatted; guard against null tech.
                 val ndef = Ndef.get(tag)
                 if (ndef == null) {

--- a/app/src/main/java/com/hexxotest/spoolcompanion/ui/NfcTagViewModel.kt
+++ b/app/src/main/java/com/hexxotest/spoolcompanion/ui/NfcTagViewModel.kt
@@ -31,6 +31,11 @@ class NfcTagViewModel(application: Application) : AndroidViewModel(application) 
             val sharedPrefs = getApplication<Application>().getSharedPreferences("settings", Context.MODE_PRIVATE)
             return sharedPrefs.getString("spoolman_url", null)
         }
+    val addUrlToNfc: Boolean
+        get() {
+            val sharedPrefs = getApplication<Application>().getSharedPreferences("settings", Context.MODE_PRIVATE)
+            return sharedPrefs.getBoolean("spoolman_nfc_url", false)
+        }
 }
 
 // Parsed tag payload + tag UID for the read dialog.

--- a/app/src/main/java/com/hexxotest/spoolcompanion/ui/NfcTagViewModel.kt
+++ b/app/src/main/java/com/hexxotest/spoolcompanion/ui/NfcTagViewModel.kt
@@ -1,12 +1,14 @@
 package com.hexxotest.spoolcompanion.ui
 
+import android.app.Application
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 
-class NfcTagViewModel : ViewModel() {
+class NfcTagViewModel(application: Application) : AndroidViewModel(application) {
 
     // Selected spool ID for the next NFC write. -1 indicates "none selected".
     var spoolId by mutableIntStateOf(-1)
@@ -23,6 +25,12 @@ class NfcTagViewModel : ViewModel() {
     // Error message for NFC write failures (shown in a dialog).
     var writeErrorMessage by mutableStateOf<String?>(null)
 
+    // Spoolman URL. This is a computed property to ensure it's always fresh.
+    val spoolmanUrl: String?
+        get() {
+            val sharedPrefs = getApplication<Application>().getSharedPreferences("settings", Context.MODE_PRIVATE)
+            return sharedPrefs.getString("spoolman_url", null)
+        }
 }
 
 // Parsed tag payload + tag UID for the read dialog.

--- a/app/src/main/java/com/hexxotest/spoolcompanion/ui/SpoolCompanionApp.kt
+++ b/app/src/main/java/com/hexxotest/spoolcompanion/ui/SpoolCompanionApp.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -55,6 +57,8 @@ fun SpoolCompanionApp(nfcTagViewModel: NfcTagViewModel) {
     val sharedPrefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
     val spoolmanUrlFromPrefs = sharedPrefs.getString("spoolman_url", "")
     val spoolmanUrl = remember { mutableStateOf(spoolmanUrlFromPrefs) }
+    val spoolmanNfcUrlFromPrefs = sharedPrefs.getBoolean("spoolman_nfc_url", false)
+    val spoolmanNfcUrl = remember { mutableStateOf(spoolmanNfcUrlFromPrefs) }
     var showSettingsDialog by remember { mutableStateOf(false) }
     var isSortMenuExpanded by remember { mutableStateOf(false) }
     // Restore sort preference on app launch; fall back to Remaining when value is missing/invalid.
@@ -158,11 +162,13 @@ fun SpoolCompanionApp(nfcTagViewModel: NfcTagViewModel) {
     if (showSettingsDialog) {
         SettingsDialog(
             spoolmanUrl = spoolmanUrl,
+            spoolmanNfcUrl = spoolmanNfcUrl,
             onDismiss = { showSettingsDialog = false },
             onConfirm = {
                 // Save the cleaned base URL; SpoolApi appends "/api/v1/".
                 sharedPrefs.edit {
                     putString("spoolman_url", spoolmanUrl.value)
+                    putBoolean("spoolman_nfc_url", spoolmanNfcUrl.value)
                     apply()
                 }
                 showSettingsDialog = false
@@ -183,6 +189,7 @@ private fun android.content.SharedPreferences.readSortOption(): SortOption {
 @Composable
 fun SettingsDialog(
     spoolmanUrl: MutableState<String?>,
+    spoolmanNfcUrl: MutableState<Boolean>,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit
 ) {
@@ -222,6 +229,16 @@ fun SettingsDialog(
                     maxLines = 1,
                     singleLine = true,
                     placeholder = { Text(text = "http://0.0.0.0:7912/") })
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = spoolmanNfcUrl.value,
+                        onCheckedChange = { spoolmanNfcUrl.value = it }
+                    )
+                    Text(text = "Add URL to NFC")
+                }
             }
         }
     )


### PR DESCRIPTION
I tried it with my little knowledge about Android development ;-)
With this, the user can use SpoolCompanion to get information about the spool and without SpoolCompanion, the browser can be used to change remaining weight etc.
e.g. for spool #47:
http://spoolman.local:7912/spool/show/47

Currently, I use NFC tools to add this URL beside SpoolCompanion information, but it is not a nice workflow. It works for me, but I do not have [nfc2klipper](https://github.com/bofh69/nfc2klipper) - maybe later ;-).